### PR TITLE
feat: Simplify error messages

### DIFF
--- a/lib/sendJson.js
+++ b/lib/sendJson.js
@@ -4,11 +4,11 @@ const readJson = require('./readJson');
 
 // https://nodejs.org/api/errors.html#errors_common_system_errors
 const errorReasons = {
-	ECONNREFUSED: '(Connection refused): No connection could be made because the target machine actively refused it. This usually results from trying to connect to a service that is inactive on the foreign host.',
-	ECONNRESET: '(Connection reset by peer): A connection was forcibly closed by a peer. This normally results from a loss of the connection on the remote socket due to a timeout or reboot. Commonly encountered via the http and net modules.',
-	ETIMEDOUT: '(Operation timed out): A connect or send request failed because the connected party did not properly respond after a period of time. Usually encountered by http or net. Often a sign that a socket.end() was not properly called.',
-	ENOTFOUND: '(DNS lookup failed): Indicates a DNS failure of either EAI_NODATA or EAI_NONAME. This is not a standard POSIX error.',
-	EPIPE: '(Broken pipe): A write on a pipe, socket, or FIFO for which there is no process to read the data. Commonly encountered at the net and http layers, indicative that the remote side of the stream being written to has been closed.',
+	ECONNREFUSED: 'No connection could be made because the target machine actively refused it.',
+	ECONNRESET: ' A connection was forcibly closed by the target machine potentially due to a timeout or reboot.',
+	ETIMEDOUT: 'Send request timed out because the connected party did not properly respond after a period of time.',
+	ENOTFOUND: 'DNS lookup failure. The IP of the target could not be resolved.',
+	EPIPE: 'The remote side of the stream being written to has been closed.',
 };
 
 function sendRequest(options, data) {
@@ -50,7 +50,7 @@ async function sendJson({data, port, hostname = 'localhost', path = '/', apiKey 
 		};
 	}
 	catch (error) {
-		const {message, code, address, port} = error;
+		const {message, code, address} = error;
 		const reason = errorReasons[code];
 
 		logger.error(`[Buslane] Error sending a request to ${targetService}`, {


### PR DESCRIPTION
Simplify the error messages returned whenever a request fails.

Fixes #49