### PR TITLE
feat: Extend RPCError stack trace with the original one

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ module.exports = class Buslane {
 
 					if (status !== 200) {
 						if (debug) {
-							logger.error(`[Buslane] Bus error on ${serviceName}:${name}: `, body);
+							logger.error(`[Buslane] Bus error(s) on ${serviceName}:${name}:`, {body, currentStack: (new Error()).stack});
 						}
 
 						throw new RPCError({

--- a/lib/RPCError.js
+++ b/lib/RPCError.js
@@ -1,3 +1,33 @@
+const SKIPPED_STACK_TRACE_ENTRIES = [
+	'at runMicrotasks (',
+	'at processTicksAndRejections (',
+];
+
+function cleanUpStackTraceEntries(stackTraceEntries) {
+	return stackTraceEntries.filter(entry => {
+		const trimmedEntry = entry.trim();
+
+		return !SKIPPED_STACK_TRACE_ENTRIES.some(skippedEntry => trimmedEntry.startsWith(skippedEntry));
+	});
+}
+
+function extendStackTrace(current, extension) {
+	if (!extension) {
+		return current;
+	}
+
+	const [, ...currentEntries] = current.split('\n');
+	const [rootCause, ...extensionEntries] = extension.split('\n');
+
+	const extendedStackTrace = [
+		rootCause,
+		...cleanUpStackTraceEntries(extensionEntries),
+		...cleanUpStackTraceEntries(currentEntries),
+	];
+
+	return extendedStackTrace.join('\n');
+}
+
 class RPCError extends Error {
 	constructor({message = 'Unknown error', name, stack, code, ingress, method}) {
 		super(message);
@@ -6,7 +36,7 @@ class RPCError extends Error {
 			this.name = name;
 		}
 
-		this.stack = stack;
+		this.stack = extendStackTrace(this.stack, stack);
 		this.code = code;
 		this.ingress = ingress;
 		this.method = method;


### PR DESCRIPTION
See 5app/hub#10916

Extend the current stack trace in `RPCError` with the original error stack trace and cleanup the output to remove redundant entries like `at runMicrotasks` and `at processTicksAndRejections`

Before:

```
auth | Error in the auth service: RPCError: Throwing an error from the api service
auth |     at Database.getUserForAuth [as _getUserForAuth] (/home/node/api/db/methods/users.js:110:9)
auth |     at processTicksAndRejections (node:internal/process/task_queues:96:5) {
auth |   code: undefined,
auth |   ingress: 'api:db',
auth |   method: 'getUserForAuth'
auth | }
```

After merging the stack traces:

```
auth | Error in the auth service: RPCError: Throwing an error from the api service
auth |     at Database.getUserForAuth [as _getUserForAuth] (/home/node/api/db/methods/users.js:110:9)
auth |     at Proxy.<anonymous> (/home/node/auth/node_modules/@5app/buslane/index.js:128:13)
auth |     at async deserializeUser (file:///home/node/auth/modules/auth.js:231:17) {
auth |   code: undefined,
auth |   ingress: 'api:db',
auth |   method: 'getUserForAuth'
auth | }
```

~noissue~ 5app/hub#10916 (but i've put it at the top)